### PR TITLE
feat: expor latitude e longitude no ItemCatalogoResumoDTO

### DIFF
--- a/src/main/java/com/gabriel/party/dtos/itemcatalogo/ItemCatalogoResumoDTO.java
+++ b/src/main/java/com/gabriel/party/dtos/itemcatalogo/ItemCatalogoResumoDTO.java
@@ -45,5 +45,11 @@ public record ItemCatalogoResumoDTO(
         Double mediaAvaliacao,
 
         @Schema(description = "Total de avaliações do item", example = "25")
-        Long totalAvaliacoes
+        Long totalAvaliacoes,
+
+        @Schema(description = "Latitude do prestador — usado para posicionar o pin no mapa", example = "-23.5505")
+        Double latitude,
+
+        @Schema(description = "Longitude do prestador — usado para posicionar o pin no mapa", example = "-46.6333")
+        Double longitude
 ) {}

--- a/src/main/java/com/gabriel/party/dtos/itemcatalogo/ItemCatalogoResumoDTO.java
+++ b/src/main/java/com/gabriel/party/dtos/itemcatalogo/ItemCatalogoResumoDTO.java
@@ -47,9 +47,9 @@ public record ItemCatalogoResumoDTO(
         @Schema(description = "Total de avaliações do item", example = "25")
         Long totalAvaliacoes,
 
-        @Schema(description = "Latitude do prestador — usado para posicionar o pin no mapa", example = "-23.5505")
+        @Schema(description = "Latitude do prestador — null se coordenadas não cadastradas", example = "-23.5505")
         Double latitude,
 
-        @Schema(description = "Longitude do prestador — usado para posicionar o pin no mapa", example = "-46.6333")
+        @Schema(description = "Longitude do prestador — null se coordenadas não cadastradas", example = "-46.6333")
         Double longitude
 ) {}

--- a/src/main/java/com/gabriel/party/mapper/itemcatalogo/ItemCatalogoMapper.java
+++ b/src/main/java/com/gabriel/party/mapper/itemcatalogo/ItemCatalogoMapper.java
@@ -125,6 +125,8 @@ public interface ItemCatalogoMapper {
     @Mapping(target = "prestadorNome", source = "prestador.nomeCompleto")
     @Mapping(target = "cidade", source = "prestador.endereco.cidade")
     @Mapping(target = "estado", source = "prestador.endereco.estado")
+    @Mapping(target = "latitude", source = "prestador.endereco.latitude")
+    @Mapping(target = "longitude", source = "prestador.endereco.longitude")
     @Mapping(target = "fotoPrincipalUrl", expression = "java(primeiraFotoUrl(item))")
     ItemCatalogoResumoDTO toResumoDto(ItemCatalogo item);
 

--- a/src/main/java/com/gabriel/party/services/itemcatalogo/ItemCatalogoService.java
+++ b/src/main/java/com/gabriel/party/services/itemcatalogo/ItemCatalogoService.java
@@ -101,7 +101,8 @@ public class ItemCatalogoService {
                     resumo.categoriaId(), resumo.categoriaNome(),
                     resumo.prestadorId(), resumo.prestadorNome(),
                     resumo.cidade(), resumo.estado(), resumo.fotoPrincipalUrl(),
-                    estatisticas.getMedia(), estatisticas.getTotal()
+                    estatisticas.getMedia(), estatisticas.getTotal(),
+                    resumo.latitude(), resumo.longitude()
             );
         });
     }


### PR DESCRIPTION
Closes #35

## O que muda
- ItemCatalogoResumoDTO: adicionados campos latitude e longitude
- ItemCatalogoMapper.toResumoDto: mapeados via prestador.endereco.latitude e prestador.endereco.longitude

## Impacto
Nenhuma quebra de contrato. Frontend ja consome os campos para posicionar pins no mapa da pagina /itens.