### PR TITLE
feat: expor pedidosConcluidos no PrestadorResponseDTO

### DIFF
--- a/src/main/java/com/gabriel/party/dtos/prestador/PrestadorResponseDTO.java
+++ b/src/main/java/com/gabriel/party/dtos/prestador/PrestadorResponseDTO.java
@@ -49,7 +49,10 @@ public record PrestadorResponseDTO(
         Integer quantidadeAvaliacoes,
 
         @Schema(description = "Data em que o usuário foi criado (tb_usuarios.data_criacao)", example = "2024-05-01T14:30:00")
-        LocalDateTime dataCriacao
+        LocalDateTime dataCriacao,
+
+        @Schema(description = "Total de pedidos com status CONCLUIDO para este prestador", example = "42")
+        Long pedidosConcluidos
 ) {
 
     @Schema(description = "Resumo de categoria — id e nome")

--- a/src/main/java/com/gabriel/party/dtos/prestador/PrestadorResponseDTO.java
+++ b/src/main/java/com/gabriel/party/dtos/prestador/PrestadorResponseDTO.java
@@ -51,7 +51,7 @@ public record PrestadorResponseDTO(
         @Schema(description = "Data em que o usuário foi criado (tb_usuarios.data_criacao)", example = "2024-05-01T14:30:00")
         LocalDateTime dataCriacao,
 
-        @Schema(description = "Total de pedidos com status CONCLUIDO para este prestador", example = "42")
+        @Schema(description = "Total de pedidos aceitos (concluídos) recebidos pelo prestador", example = "42")
         Long pedidosConcluidos
 ) {
 

--- a/src/main/java/com/gabriel/party/mapper/prestador/PrestadorMapper.java
+++ b/src/main/java/com/gabriel/party/mapper/prestador/PrestadorMapper.java
@@ -30,15 +30,16 @@ public interface PrestadorMapper {
     @Mapping(target = "ativo", ignore = true)
     Prestador toEntity(PrestadorRequestDTO dto);
 
-    @Mapping(target = "nome", source = "nomeCompleto")
-    @Mapping(target = "email", source = "usuario.email")
+    @Mapping(target = "nome", source = "prestador.nomeCompleto")
+    @Mapping(target = "email", source = "prestador.usuario.email")
     @Mapping(target = "categorias", expression = "java(extrairCategorias(prestador.getItensCatalogo()))")
-    @Mapping(target = "itensCatalogo", source = "itensCatalogo", qualifiedByName = "listaAtivosItens")
-    @Mapping(target = "avaliacoes", source = "avaliacoes", qualifiedByName = "listaAtivasAvaliacoes")
+    @Mapping(target = "itensCatalogo", source = "prestador.itensCatalogo", qualifiedByName = "listaAtivosItens")
+    @Mapping(target = "avaliacoes", source = "prestador.avaliacoes", qualifiedByName = "listaAtivasAvaliacoes")
     @Mapping(target = "mediaAvaliacoes", expression = "java(calcularMedia(prestador.getAvaliacoes()))")
     @Mapping(target = "quantidadeAvaliacoes", expression = "java(calcularQuantidade(prestador.getAvaliacoes()))")
-    @Mapping(target = "dataCriacao", source = "usuario.dataCriacao")
-    PrestadorResponseDTO toDto(Prestador prestador);
+    @Mapping(target = "dataCriacao", source = "prestador.usuario.dataCriacao")
+    @Mapping(target = "pedidosConcluidos", source = "pedidosConcluidos")
+    PrestadorResponseDTO toDto(Prestador prestador, Long pedidosConcluidos);
 
     @Mapping(target = "nome", source = "nomeCompleto")
     @Mapping(target = "email", source = "usuario.email")

--- a/src/main/java/com/gabriel/party/repositories/pedido/PedidoRepository.java
+++ b/src/main/java/com/gabriel/party/repositories/pedido/PedidoRepository.java
@@ -27,6 +27,8 @@ public interface PedidoRepository extends JpaRepository<Pedido, UUID> {
 
     List<Pedido> findByStatusPedidoAndValidadeOrcamentoBefore(StatusPedido status, LocalDateTime agora);
 
+    Long countByPrestadorIdAndStatusPedido(UUID prestadorId, StatusPedido status);
+
     @Modifying
     @Query("UPDATE Pedido p SET p.statusPedido = :novoStatus WHERE p.statusPedido = :statusAtual AND p.validadeOrcamento < :agora")
     int expirarOrcamentosVencidos(StatusPedido statusAtual, StatusPedido novoStatus, LocalDateTime agora);

--- a/src/main/java/com/gabriel/party/services/prestador/PrestadorService.java
+++ b/src/main/java/com/gabriel/party/services/prestador/PrestadorService.java
@@ -14,6 +14,8 @@ import com.gabriel.party.model.prestador.Prestador;
 import com.gabriel.party.model.usuario.Usuario;
 import com.gabriel.party.repositories.Usuario.UsuarioRepository;
 import com.gabriel.party.repositories.categoria.CategoriaRepository;
+import com.gabriel.party.model.pedido.enums.StatusPedido;
+import com.gabriel.party.repositories.pedido.PedidoRepository;
 import com.gabriel.party.repositories.prestador.PrestadorRepository;
 import com.gabriel.party.services.integracoes.aws.ArmazenamentoService;
 import com.gabriel.party.services.integracoes.geocoding.GeocodingService;
@@ -40,6 +42,7 @@ public class PrestadorService {
     private final GeocodingService geocodingService;
     private final UsuarioRepository usuarioRepository;
     private final ArmazenamentoService armazenamentoService;
+    private final PedidoRepository pedidoRepository;
     private final Logger logger = Logger.getLogger(PrestadorService.class.getName());
 
     public PrestadorService(PrestadorRepository repository,
@@ -47,7 +50,9 @@ public class PrestadorService {
                             CategoriaRepository categoriaRepository,
                             PrestadorMapper mapper,
                             GeocodingService geocodingService,
-                            UsuarioRepository usuarioRepository, ArmazenamentoService armazenamentoService) {
+                            UsuarioRepository usuarioRepository,
+                            ArmazenamentoService armazenamentoService,
+                            PedidoRepository pedidoRepository) {
         this.repository = repository;
         this.usuarioMapper = usuarioMapper;
         this.categoriaRepository = categoriaRepository;
@@ -55,6 +60,7 @@ public class PrestadorService {
         this.geocodingService = geocodingService;
         this.usuarioRepository = usuarioRepository;
         this.armazenamentoService = armazenamentoService;
+        this.pedidoRepository = pedidoRepository;
     }
 
     @Transactional
@@ -93,10 +99,10 @@ public class PrestadorService {
 
     @Transactional(readOnly = true)
     public PrestadorResponseDTO buscarPrestadorPorId(UUID id) {
-
         var prestador = repository.findByIdComMidias(id)
                 .orElseThrow(() -> new AppException(ErrorCode.PRESTADOR_NAO_ENCONTRADO, id.toString()));
-        return mapper.toDto(prestador);
+        Long pedidosConcluidos = pedidoRepository.countByPrestadorIdAndStatusPedido(id, StatusPedido.CONCLUIDO);
+        return mapper.toDto(prestador, pedidosConcluidos);
     }
 
     @Transactional
@@ -119,7 +125,8 @@ public class PrestadorService {
         }
 
         repository.save(prestador);
-        return mapper.toDto(prestador);
+        Long pedidosConcluidos = pedidoRepository.countByPrestadorIdAndStatusPedido(id, StatusPedido.CONCLUIDO);
+        return mapper.toDto(prestador, pedidosConcluidos);
     }
 
     @Transactional

--- a/src/main/java/com/gabriel/party/services/prestador/PrestadorService.java
+++ b/src/main/java/com/gabriel/party/services/prestador/PrestadorService.java
@@ -101,7 +101,7 @@ public class PrestadorService {
     public PrestadorResponseDTO buscarPrestadorPorId(UUID id) {
         var prestador = repository.findByIdComMidias(id)
                 .orElseThrow(() -> new AppException(ErrorCode.PRESTADOR_NAO_ENCONTRADO, id.toString()));
-        Long pedidosConcluidos = pedidoRepository.countByPrestadorIdAndStatusPedido(id, StatusPedido.CONCLUIDO);
+        Long pedidosConcluidos = pedidoRepository.countByPrestadorIdAndStatusPedido(id, StatusPedido.ACEITO);
         return mapper.toDto(prestador, pedidosConcluidos);
     }
 
@@ -125,7 +125,7 @@ public class PrestadorService {
         }
 
         repository.save(prestador);
-        Long pedidosConcluidos = pedidoRepository.countByPrestadorIdAndStatusPedido(id, StatusPedido.CONCLUIDO);
+        Long pedidosConcluidos = pedidoRepository.countByPrestadorIdAndStatusPedido(id, StatusPedido.ACEITO);
         return mapper.toDto(prestador, pedidosConcluidos);
     }
 


### PR DESCRIPTION
Closes #39

## O que muda
- PrestadorResponseDTO: adicionado campo pedidosConcluidos (Long)
- PedidoRepository: adicionado countByPrestadorIdAndStatusPedido (derived query)
- PrestadorMapper.toDto: assinatura alterada para receber Long pedidosConcluidos como segundo parametro (multi-source MapStruct)
- PrestadorService: injetado PedidoRepository; buscarPrestadorPorId e atualizarPrestador passam a contagem ao mapper

## Impacto
Nenhuma quebra de contrato existente. Frontend ja consome o campo pedidosConcluidos na sidebar do perfil publico.