### PR TITLE
feat: adicionar fotoBannerUrl no Prestador

### DIFF
--- a/src/main/java/com/gabriel/party/controllers/prestador/PrestadorController.java
+++ b/src/main/java/com/gabriel/party/controllers/prestador/PrestadorController.java
@@ -105,6 +105,20 @@ public class PrestadorController {
         return ResponseEntity.ok(Map.of("fotoPerfilUrl", url));
     }
 
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Foto de capa atualizada"),
+            @ApiResponse(responseCode = "400", description = "Arquivo inválido ou formato não suportado"),
+            @ApiResponse(responseCode = "404", description = "Prestador não encontrado")
+    })
+    @Operation(summary = "Atualizar foto de capa", description = "Faz upload de uma nova foto de capa. A foto anterior é removida do storage.")
+    @PutMapping(value = "/{id}/foto-banner", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("hasAnyRole('ROLE_PRESTADOR', 'ROLE_ADMINISTRADOR')")
+    public ResponseEntity<Map<String, String>> atualizarFotoBanner(@PathVariable UUID id,
+                                                                   @RequestPart("arquivo") MultipartFile arquivo) {
+        String url = prestadorService.atualizarFotoBanner(id, arquivo);
+        return ResponseEntity.ok(Map.of("fotoBannerUrl", url));
+    }
+
     @ApiResponses( value = {
             @ApiResponse(responseCode = "204", description = "Prestador inativado com sucesso"),
             @ApiResponse(responseCode = "404", description = "Prestador não encontrado")

--- a/src/main/java/com/gabriel/party/dtos/prestador/PrestadorResponseDTO.java
+++ b/src/main/java/com/gabriel/party/dtos/prestador/PrestadorResponseDTO.java
@@ -33,6 +33,9 @@ public record PrestadorResponseDTO(
         @Schema(description = "URL da foto de perfil")
         String fotoPerfilUrl,
 
+        @Schema(description = "URL da foto de capa do perfil público — null se não definida")
+        String fotoBannerUrl,
+
         @Schema(description = "Endereço do prestador")
         EnderecoDTO endereco,
 

--- a/src/main/java/com/gabriel/party/model/prestador/Prestador.java
+++ b/src/main/java/com/gabriel/party/model/prestador/Prestador.java
@@ -41,6 +41,9 @@ public class Prestador {
     @Column(name = "foto_perfil_url", nullable = true)
     private String fotoPerfilUrl;
 
+    @Column(name = "foto_banner_url", nullable = true)
+    private String fotoBannerUrl;
+
     @Embedded
     private Endereco endereco;
 

--- a/src/main/java/com/gabriel/party/services/prestador/PrestadorService.java
+++ b/src/main/java/com/gabriel/party/services/prestador/PrestadorService.java
@@ -154,6 +154,27 @@ public class PrestadorService {
         return urlNova;
     }
 
+    @Transactional
+    public String atualizarFotoBanner(UUID id, MultipartFile arquivo) {
+        var prestador = repository.findByIdAndAtivoTrue(id)
+                .orElseThrow(() -> new AppException(ErrorCode.PRESTADOR_NAO_ENCONTRADO, id.toString()));
+
+        String contentType = arquivo.getContentType();
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw new AppException(ErrorCode.FORMATO_INVALIDO, contentType == null ? "desconhecido" : contentType);
+        }
+
+        String urlAntiga = prestador.getFotoBannerUrl();
+        String urlNova = armazenamentoService.salvarMidias(arquivo);
+        prestador.setFotoBannerUrl(urlNova);
+        repository.save(prestador);
+
+        if (urlAntiga != null && !urlAntiga.isBlank()) {
+            try { armazenamentoService.deletaMidia(urlAntiga); } catch (Exception ignored) {}
+        }
+        return urlNova;
+    }
+
     /**
      * Busca detalhe administrativo do prestador — inclui CNPJ/CPF, endereço
      * completo, whatsapp e data de criação. Acesso restrito a

--- a/src/main/resources/liquibase/base-changelog.xml
+++ b/src/main/resources/liquibase/base-changelog.xml
@@ -8,5 +8,6 @@
             <include relativeToChangelogFile="true" file="changelog-0.2.0.xml"/>
             <include relativeToChangelogFile="true" file="changelog-0.3.0.xml"/>
             <include relativeToChangelogFile="true" file="changelog-0.4.0.xml"/>
+            <include relativeToChangelogFile="true" file="changelog-0.5.0.xml"/>
             
 </databaseChangeLog>

--- a/src/main/resources/liquibase/changelog-0.5.0.xml
+++ b/src/main/resources/liquibase/changelog-0.5.0.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet author="GF" id="0.5.0-prestador-foto-banner-url">
+        <addColumn tableName="tb_prestador">
+            <column name="foto_banner_url" type="VARCHAR(500)" remarks="URL da foto de capa do perfil publico do prestador."/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
Closes #37

## O que muda
- Liquibase changelog-0.5.0: coluna foto_banner_url VARCHAR(500) em tb_prestador
- Prestador.java: campo fotoBannerUrl adicionado
- PrestadorResponseDTO: campo fotoBannerUrl exposto (MapStruct auto-mapeia por nome)
- PrestadorService: metodo atualizarFotoBanner com mesma logica de atualizarFotoPerfil (upload + delete do arquivo antigo)
- PrestadorController: endpoint PUT /prestadores/{id}/foto-banner

## Impacto
Nenhuma quebra de contrato. Campo novo no response (null para prestadores existentes). Endpoint protegido por ROLE_PRESTADOR ou ROLE_ADMINISTRADOR.