### PR TITLE
feat: moderação de admin — remover mídia e itens (#59)

### DIFF
--- a/src/main/java/com/gabriel/party/controllers/admin/AdminModeracaoController.java
+++ b/src/main/java/com/gabriel/party/controllers/admin/AdminModeracaoController.java
@@ -1,0 +1,55 @@
+package com.gabriel.party.controllers.admin;
+
+import com.gabriel.party.services.itemcatalogo.ItemCatalogoService;
+import com.gabriel.party.services.midia.MidiaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@CrossOrigin(origins = "*")
+@RestController
+@RequestMapping("/api/v1/admin")
+@PreAuthorize("hasRole('ROLE_ADMINISTRADOR')")
+@Tag(name = "Moderação (Admin)", description = "Endpoints de moderação de conteúdo, restritos ao administrador")
+public class AdminModeracaoController {
+
+    private final MidiaService midiaService;
+    private final ItemCatalogoService itemCatalogoService;
+
+    public AdminModeracaoController(MidiaService midiaService, ItemCatalogoService itemCatalogoService) {
+        this.midiaService = midiaService;
+        this.itemCatalogoService = itemCatalogoService;
+    }
+
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Mídia removida com sucesso"),
+            @ApiResponse(responseCode = "403", description = "Apenas administradores podem moderar conteúdo"),
+            @ApiResponse(responseCode = "404", description = "Mídia não encontrada")
+    })
+    @Operation(summary = "Moderar (remover) mídia de qualquer prestador",
+            description = "Remove a mídia do S3 e do banco, independentemente do dono, e notifica o prestador por e-mail.")
+    @DeleteMapping("/midias/{id}")
+    public ResponseEntity<Void> moderarMidia(@PathVariable UUID id) {
+        midiaService.deletarComoModerador(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Item removido com sucesso"),
+            @ApiResponse(responseCode = "403", description = "Apenas administradores podem moderar conteúdo"),
+            @ApiResponse(responseCode = "404", description = "Item de catálogo não encontrado")
+    })
+    @Operation(summary = "Moderar (remover) item de catálogo de qualquer prestador",
+            description = "Inativa (soft-delete) o item, independentemente do dono, e notifica o prestador por e-mail.")
+    @DeleteMapping("/itens-catalogo/{id}")
+    public ResponseEntity<Void> moderarItemCatalogo(@PathVariable UUID id) {
+        itemCatalogoService.removerComoModerador(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/gabriel/party/services/email/EmailService.java
+++ b/src/main/java/com/gabriel/party/services/email/EmailService.java
@@ -10,6 +10,8 @@ import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.logging.Logger;
 
@@ -43,6 +45,24 @@ public class EmailService {
             logger.info("Email enviado para: " + destinatario + " | " + assunto);
         } catch (MessagingException | MailException e) {
             logger.severe("Falha ao enviar email para " + destinatario + ": " + e.getMessage());
+        }
+    }
+
+    /**
+     * Envia o e-mail somente após o commit da transação atual, evitando notificar
+     * o destinatário caso a transação sofra rollback. Fora de uma transação ativa,
+     * envia imediatamente.
+     */
+    public void enviarAposCommit(String destinatario, String assunto, String corpoHtml) {
+        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    enviarEmail(destinatario, assunto, corpoHtml);
+                }
+            });
+        } else {
+            enviarEmail(destinatario, assunto, corpoHtml);
         }
     }
 }

--- a/src/main/java/com/gabriel/party/services/email/EmailTemplates.java
+++ b/src/main/java/com/gabriel/party/services/email/EmailTemplates.java
@@ -193,6 +193,41 @@ public class EmailTemplates {
                 rodape
         );
     }
+    public static String midiaRemovidaPorModeracao(String nomePrestador, String tipoMidia, String tituloItem) {
+        String detalhes =
+                linha("Tipo de mídia", tipoMidia) +
+                linha("Item associado", tituloItem);
+
+        String rodape = caixa("aviso",
+                "A remoção foi feita por nossa equipe de moderação por não estar de acordo com as diretrizes da plataforma. " +
+                "Em caso de dúvidas, entre em contato com o suporte do FestConnect.");
+
+        return construir(
+                "Conteúdo removido por moderação",
+                "Olá, " + nomePrestador + ".",
+                "Uma mídia da sua vitrine foi removida pela equipe de moderação do FestConnect.",
+                detalhes,
+                rodape
+        );
+    }
+
+    public static String itemRemovidoPorModeracao(String nomePrestador, String tituloItem) {
+        String detalhes =
+                linha("Item removido", tituloItem);
+
+        String rodape = caixa("aviso",
+                "A remoção foi feita por nossa equipe de moderação por não estar de acordo com as diretrizes da plataforma. " +
+                "Em caso de dúvidas, entre em contato com o suporte do FestConnect.");
+
+        return construir(
+                "Item removido por moderação",
+                "Olá, " + nomePrestador + ".",
+                "Um item do seu catálogo foi removido pela equipe de moderação do FestConnect.",
+                detalhes,
+                rodape
+        );
+    }
+
     // --- Construtores internos ---
 
     private static String construir(String titulo, String saudacao, String mensagem, String linhasDetalhes, String rodapeExtra) {

--- a/src/main/java/com/gabriel/party/services/itemcatalogo/ItemCatalogoService.java
+++ b/src/main/java/com/gabriel/party/services/itemcatalogo/ItemCatalogoService.java
@@ -13,6 +13,8 @@ import com.gabriel.party.repositories.avaliacao.EstatisticasItemAvaliacao;
 import com.gabriel.party.repositories.categoria.CategoriaRepository;
 import com.gabriel.party.repositories.itemcatalogo.ItemCatalogoRepository;
 import com.gabriel.party.repositories.prestador.PrestadorRepository;
+import com.gabriel.party.services.email.EmailService;
+import com.gabriel.party.services.email.EmailTemplates;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -31,17 +33,20 @@ public class ItemCatalogoService {
     private final CategoriaRepository categoriaRepository;
     private final ItemCatalogoMapper itemCatalogoMapper;
     private final AvaliacaoRepository avaliacaoRepository;
+    private final EmailService emailService;
 
     public ItemCatalogoService(ItemCatalogoRepository itemCatalogoRepository,
             PrestadorRepository prestadorRepository,
             CategoriaRepository categoriaRepository,
             ItemCatalogoMapper itemCatalogoMapper,
-            AvaliacaoRepository avaliacaoRepository) {
+            AvaliacaoRepository avaliacaoRepository,
+            EmailService emailService) {
         this.itemCatalogoRepository = itemCatalogoRepository;
         this.prestadorRepository = prestadorRepository;
         this.categoriaRepository = categoriaRepository;
         this.itemCatalogoMapper = itemCatalogoMapper;
         this.avaliacaoRepository = avaliacaoRepository;
+        this.emailService = emailService;
     }
 
     @Transactional
@@ -150,6 +155,25 @@ public class ItemCatalogoService {
                 .orElseThrow(() -> new AppException(ErrorCode.ITEM_CATALOGO_NAO_ENCONTRADO, id.toString()));
         itemCatalogo.setAtivo(false);
         itemCatalogoRepository.save(itemCatalogo);
+    }
+
+    /**
+     * Remoção por moderação: o admin inativa (soft-delete) o item de qualquer
+     * prestador, sem checagem de dono. Notifica o prestador dono por e-mail após o commit.
+     */
+    @Transactional
+    public void removerComoModerador(UUID id) {
+        var itemCatalogo = itemCatalogoRepository.findByIdAndAtivoTrue(id)
+                .orElseThrow(() -> new AppException(ErrorCode.ITEM_CATALOGO_NAO_ENCONTRADO, id.toString()));
+
+        itemCatalogo.setAtivo(false);
+        itemCatalogoRepository.save(itemCatalogo);
+
+        Prestador prestador = itemCatalogo.getPrestador();
+        emailService.enviarAposCommit(
+                prestador.getUsuario().getEmail(),
+                "Item removido por moderação — FestConnect",
+                EmailTemplates.itemRemovidoPorModeracao(prestador.getNomeCompleto(), itemCatalogo.getTitulo()));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/gabriel/party/services/midia/MidiaService.java
+++ b/src/main/java/com/gabriel/party/services/midia/MidiaService.java
@@ -10,6 +10,8 @@ import com.gabriel.party.model.midia.enums.TipoMidia;
 import com.gabriel.party.repositories.itemcatalogo.ItemCatalogoRepository;
 import com.gabriel.party.repositories.midia.MidiaRepository;
 import com.gabriel.party.repositories.prestador.PrestadorRepository;
+import com.gabriel.party.services.email.EmailService;
+import com.gabriel.party.services.email.EmailTemplates;
 import com.gabriel.party.services.integracoes.aws.ArmazenamentoService;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
@@ -28,17 +30,20 @@ public class MidiaService {
     private final ItemCatalogoRepository itemCatalogoRepository;
     private final MidiaMapper mapper;
     private final ArmazenamentoService armazenamentoService;
+    private final EmailService emailService;
 
     public MidiaService(MidiaRepository repository,
                         PrestadorRepository prestadorRepository,
                         ItemCatalogoRepository itemCatalogoRepository,
                         MidiaMapper mapper,
-                        ArmazenamentoService armazenamentoService) {
+                        ArmazenamentoService armazenamentoService,
+                        EmailService emailService) {
         this.repository = repository;
         this.prestadorRepository = prestadorRepository;
         this.itemCatalogoRepository = itemCatalogoRepository;
         this.mapper = mapper;
         this.armazenamentoService = armazenamentoService;
+        this.emailService = emailService;
     }
 
     @Transactional
@@ -134,5 +139,27 @@ public class MidiaService {
 
         armazenamentoService.deletaMidia(midia.getUrl());
         repository.delete(midia);
+    }
+
+    /**
+     * Remoção por moderação: o admin deleta a mídia de qualquer prestador,
+     * sem checagem de dono. Notifica o prestador dono por e-mail após o commit.
+     */
+    @Transactional
+    public void deletarComoModerador(UUID id) {
+        var midia = repository.findById(id)
+                .orElseThrow(() -> new AppException(ErrorCode.MIDIA_NAO_ENCONTRADA, id.toString()));
+
+        var prestador = midia.getItemCatalogo().getPrestador();
+        var tituloItem = midia.getItemCatalogo().getTitulo();
+        var tipoMidia = midia.getTipo() != null ? midia.getTipo().name() : "Mídia";
+
+        armazenamentoService.deletaMidia(midia.getUrl());
+        repository.delete(midia);
+
+        emailService.enviarAposCommit(
+                prestador.getUsuario().getEmail(),
+                "Conteúdo removido por moderação — FestConnect",
+                EmailTemplates.midiaRemovidaPorModeracao(prestador.getNomeCompleto(), tipoMidia, tituloItem));
     }
 }

--- a/src/test/java/com/gabriel/party/services/itemcatalogo/ItemCatalogoServiceTest.java
+++ b/src/test/java/com/gabriel/party/services/itemcatalogo/ItemCatalogoServiceTest.java
@@ -1,0 +1,90 @@
+package com.gabriel.party.services.itemcatalogo;
+
+import com.gabriel.party.exceptions.AppException;
+import com.gabriel.party.mapper.itemcatalogo.ItemCatalogoMapper;
+import com.gabriel.party.model.itemcatalogo.ItemCatalogo;
+import com.gabriel.party.model.itemcatalogo.Servico;
+import com.gabriel.party.model.prestador.Prestador;
+import com.gabriel.party.model.usuario.Usuario;
+import com.gabriel.party.repositories.avaliacao.AvaliacaoRepository;
+import com.gabriel.party.repositories.categoria.CategoriaRepository;
+import com.gabriel.party.repositories.itemcatalogo.ItemCatalogoRepository;
+import com.gabriel.party.repositories.prestador.PrestadorRepository;
+import com.gabriel.party.services.email.EmailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ItemCatalogoServiceTest {
+
+    @Mock private ItemCatalogoRepository itemCatalogoRepository;
+    @Mock private PrestadorRepository prestadorRepository;
+    @Mock private CategoriaRepository categoriaRepository;
+    @Mock private ItemCatalogoMapper itemCatalogoMapper;
+    @Mock private AvaliacaoRepository avaliacaoRepository;
+    @Mock private EmailService emailService;
+
+    private ItemCatalogoService service;
+    private ItemCatalogo item;
+
+    @BeforeEach
+    void setUp() {
+        service = new ItemCatalogoService(itemCatalogoRepository, prestadorRepository,
+                categoriaRepository, itemCatalogoMapper, avaliacaoRepository, emailService);
+
+        var usuarioPrestador = new Usuario();
+        usuarioPrestador.setEmail("prestador@test.com");
+
+        var prestador = new Prestador();
+        prestador.setId(UUID.randomUUID());
+        prestador.setNomeCompleto("Prestador Teste");
+        prestador.setUsuario(usuarioPrestador);
+
+        item = new Servico();
+        item.setId(UUID.randomUUID());
+        item.setTitulo("Show Pirotécnico");
+        item.setAtivo(true);
+        item.setPrestador(prestador);
+    }
+
+    @Test
+    @DisplayName("removerComoModerador inativa o item e notifica o prestador, sem checar dono")
+    void removerComoModerador_inativaENotifica() {
+        when(itemCatalogoRepository.findByIdAndAtivoTrue(item.getId())).thenReturn(Optional.of(item));
+
+        service.removerComoModerador(item.getId());
+
+        assertThat(item.getAtivo()).isFalse();
+        verify(itemCatalogoRepository).save(item);
+        verify(emailService).enviarAposCommit(eq("prestador@test.com"), contains("moderação"), contains("Show Pirotécnico"));
+        // Moderação não passa pela checagem de dono
+        verifyNoInteractions(prestadorRepository);
+    }
+
+    @Test
+    @DisplayName("removerComoModerador lança exceção quando o item não existe ou já está inativo")
+    void removerComoModerador_itemInexistente() {
+        var id = UUID.randomUUID();
+        when(itemCatalogoRepository.findByIdAndAtivoTrue(id)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.removerComoModerador(id))
+                .isInstanceOf(AppException.class);
+
+        verifyNoInteractions(emailService);
+    }
+}

--- a/src/test/java/com/gabriel/party/services/midia/MidiaServiceTest.java
+++ b/src/test/java/com/gabriel/party/services/midia/MidiaServiceTest.java
@@ -1,0 +1,97 @@
+package com.gabriel.party.services.midia;
+
+import com.gabriel.party.exceptions.AppException;
+import com.gabriel.party.mapper.midia.MidiaMapper;
+import com.gabriel.party.model.itemcatalogo.ItemCatalogo;
+import com.gabriel.party.model.itemcatalogo.Servico;
+import com.gabriel.party.model.midia.Midia;
+import com.gabriel.party.model.midia.enums.TipoMidia;
+import com.gabriel.party.model.prestador.Prestador;
+import com.gabriel.party.model.usuario.Usuario;
+import com.gabriel.party.repositories.itemcatalogo.ItemCatalogoRepository;
+import com.gabriel.party.repositories.midia.MidiaRepository;
+import com.gabriel.party.repositories.prestador.PrestadorRepository;
+import com.gabriel.party.services.email.EmailService;
+import com.gabriel.party.services.integracoes.aws.ArmazenamentoService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MidiaServiceTest {
+
+    @Mock private MidiaRepository repository;
+    @Mock private PrestadorRepository prestadorRepository;
+    @Mock private ItemCatalogoRepository itemCatalogoRepository;
+    @Mock private MidiaMapper mapper;
+    @Mock private ArmazenamentoService armazenamentoService;
+    @Mock private EmailService emailService;
+
+    private MidiaService service;
+    private Midia midia;
+
+    @BeforeEach
+    void setUp() {
+        service = new MidiaService(repository, prestadorRepository, itemCatalogoRepository,
+                mapper, armazenamentoService, emailService);
+
+        var usuarioPrestador = new Usuario();
+        usuarioPrestador.setEmail("prestador@test.com");
+
+        var prestador = new Prestador();
+        prestador.setId(UUID.randomUUID());
+        prestador.setNomeCompleto("Prestador Teste");
+        prestador.setUsuario(usuarioPrestador);
+
+        ItemCatalogo item = new Servico();
+        item.setId(UUID.randomUUID());
+        item.setTitulo("Buffet Premium");
+        item.setPrestador(prestador);
+
+        midia = new Midia();
+        midia.setId(UUID.randomUUID());
+        midia.setUrl("https://s3/midia.jpg");
+        midia.setTipo(TipoMidia.FOTO);
+        midia.setItemCatalogo(item);
+    }
+
+    @Test
+    @DisplayName("deletarComoModerador remove do S3, do banco e notifica o prestador, sem checar dono")
+    void deletarComoModerador_removeENotifica() {
+        when(repository.findById(midia.getId())).thenReturn(Optional.of(midia));
+
+        service.deletarComoModerador(midia.getId());
+
+        verify(armazenamentoService).deletaMidia("https://s3/midia.jpg");
+        verify(repository).delete(midia);
+        verify(emailService).enviarAposCommit(eq("prestador@test.com"), contains("moderação"), contains("Prestador Teste"));
+        // Moderação não passa pela checagem de dono
+        verifyNoInteractions(prestadorRepository);
+    }
+
+    @Test
+    @DisplayName("deletarComoModerador lança exceção quando a mídia não existe")
+    void deletarComoModerador_midiaInexistente() {
+        var id = UUID.randomUUID();
+        when(repository.findById(id)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.deletarComoModerador(id))
+                .isInstanceOf(AppException.class);
+
+        verifyNoInteractions(armazenamentoService);
+        verifyNoInteractions(emailService);
+    }
+}


### PR DESCRIPTION
Closes #59

## O que faz
Dá ao admin poder de **moderação de conteúdo**: remover mídia e itens de catálogo de **qualquer** prestador, via endpoints dedicados.

## Endpoints (restritos a `ROLE_ADMINISTRADOR`)
- `DELETE /api/v1/admin/midias/{id}` — remove a mídia do S3 e do banco, sem checagem de dono.
- `DELETE /api/v1/admin/itens-catalogo/{id}` — soft-delete (`ativo=false`) do item, consistente com o fluxo atual.

Em ambos, o **prestador dono é notificado por e-mail** (sem motivo persistido), enviado via `afterCommit`.

## Decisões
- **Endpoints dedicados** (não reuso do DELETE do dono) para separar 'moderador' de 'dono' e manter auditável.
- Novo helper `EmailService.enviarAposCommit` centraliza o padrão `afterCommit` (encaminha a #57).
- Item segue **soft-delete**; mídias vinculadas a um item moderado permanecem (moderação de mídia é individual).

## Testes
- `MidiaServiceTest` e `ItemCatalogoServiceTest`: provam que a moderação remove/inativa, notifica o prestador e **não passa pela checagem de dono** (`verifyNoInteractions(prestadorRepository)`).

## Frontend
PR correspondente no repo `festconnect-frontend` (mesma branch `59-moderacao-admin`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)