### PR TITLE
Débito técnico: #57, #55, #53 (backend)

### DIFF
--- a/src/main/java/com/gabriel/party/config/infra/security/TokenService.java
+++ b/src/main/java/com/gabriel/party/config/infra/security/TokenService.java
@@ -27,6 +27,10 @@ public class TokenService {
     }
 
     public String gerarToken(Usuario usuario, UUID profileId, String nome) {
+        return gerarToken(usuario, profileId, nome, null);
+    }
+
+    public String gerarToken(Usuario usuario, UUID profileId, String nome, String fotoPerfilUrl) {
         try {
             Algorithm algorithm = Algorithm.HMAC256(segredo);
 
@@ -42,6 +46,9 @@ public class TokenService {
             }
             if (nome != null && !nome.isBlank()) {
                 builder = builder.withClaim("nome", nome);
+            }
+            if (fotoPerfilUrl != null && !fotoPerfilUrl.isBlank()) {
+                builder = builder.withClaim("fotoPerfilUrl", fotoPerfilUrl);
             }
 
             return builder.sign(algorithm);

--- a/src/main/java/com/gabriel/party/controllers/autenticacao/AutenticacaoController.java
+++ b/src/main/java/com/gabriel/party/controllers/autenticacao/AutenticacaoController.java
@@ -60,15 +60,16 @@ public class AutenticacaoController {
 
             UUID profileId = null;
             String nomeCompleto = null;
+            String fotoPerfilUrl = null;
             if (usuario.getRole() == Role.ROLE_CLIENTE) {
                 var cliente = clienteRepository.findByUsuarioId(usuario.getId()).orElse(null);
-                if (cliente != null) { profileId = cliente.getId(); nomeCompleto = cliente.getNomeCompleto(); }
+                if (cliente != null) { profileId = cliente.getId(); nomeCompleto = cliente.getNomeCompleto(); fotoPerfilUrl = cliente.getFotoPerfilUrl(); }
             } else if (usuario.getRole() == Role.ROLE_PRESTADOR) {
                 var prestador = prestadorRepository.findByUsuarioId(usuario.getId()).orElse(null);
-                if (prestador != null) { profileId = prestador.getId(); nomeCompleto = prestador.getNomeCompleto(); }
+                if (prestador != null) { profileId = prestador.getId(); nomeCompleto = prestador.getNomeCompleto(); fotoPerfilUrl = prestador.getFotoPerfilUrl(); }
             }
 
-            var tokenJwt = tokenService.gerarToken(usuario, profileId, nomeCompleto);
+            var tokenJwt = tokenService.gerarToken(usuario, profileId, nomeCompleto, fotoPerfilUrl);
             return ResponseEntity.ok(new TokenResponseDTO(tokenJwt));
 
         } catch (BadCredentialsException e) {

--- a/src/main/java/com/gabriel/party/controllers/pedido/PedidoController.java
+++ b/src/main/java/com/gabriel/party/controllers/pedido/PedidoController.java
@@ -151,4 +151,19 @@ public class PedidoController {
         pedidoService.cancelarPedidoPeloCliente(id, usuario);
         return ResponseEntity.noContent().build();
     }
+
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Orçamento recusado e prestador notificado por e-mail"),
+            @ApiResponse(responseCode = "400", description = "Pedido não está com status ORCADO"),
+            @ApiResponse(responseCode = "403", description = "Pedido não pertence a este cliente"),
+            @ApiResponse(responseCode = "404", description = "Pedido não encontrado")
+    })
+    @Operation(summary = "Recusar orçamento", description = "O cliente recusa o orçamento enviado pelo prestador. Status muda para RECUSADO. Exige status atual = ORCADO.")
+    @PutMapping("/{id}/recusar-orcamento")
+    @PreAuthorize("hasRole('ROLE_CLIENTE')")
+    public ResponseEntity<Void> recusarOrcamento(@PathVariable UUID id,
+                                                 @AuthenticationPrincipal Usuario usuario) {
+        pedidoService.recusarOrcamentoPeloCliente(id, usuario);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/gabriel/party/services/autenticacao/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/gabriel/party/services/autenticacao/OAuth2LoginSuccessHandler.java
@@ -79,14 +79,15 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
 
         UUID profileId = null;
         String nomeCompleto = null;
+        String fotoPerfil = null;
         if (usuario.getRole() == Role.ROLE_CLIENTE) {
             var cliente = clienteRepository.findByUsuarioId(usuario.getId()).orElse(null);
-            if (cliente != null) { profileId = cliente.getId(); nomeCompleto = cliente.getNomeCompleto(); }
+            if (cliente != null) { profileId = cliente.getId(); nomeCompleto = cliente.getNomeCompleto(); fotoPerfil = cliente.getFotoPerfilUrl(); }
         } else if (usuario.getRole() == Role.ROLE_PRESTADOR) {
             var prestador = prestadorRepository.findByUsuarioId(usuario.getId()).orElse(null);
-            if (prestador != null) { profileId = prestador.getId(); nomeCompleto = prestador.getNomeCompleto(); }
+            if (prestador != null) { profileId = prestador.getId(); nomeCompleto = prestador.getNomeCompleto(); fotoPerfil = prestador.getFotoPerfilUrl(); }
         }
-        String tokenJwt = tokenService.gerarToken(usuario, profileId, nomeCompleto);
+        String tokenJwt = tokenService.gerarToken(usuario, profileId, nomeCompleto, fotoPerfil);
         response.sendRedirect(frontendUrl + "/oauth2/callback?token=" + tokenJwt);
     }
 }

--- a/src/main/java/com/gabriel/party/services/email/EmailTemplates.java
+++ b/src/main/java/com/gabriel/party/services/email/EmailTemplates.java
@@ -193,6 +193,27 @@ public class EmailTemplates {
                 rodape
         );
     }
+    public static String orcamentoRecusadoPeloClienteParaPrestador(Pedido pedido) {
+        String nomePrestador = pedido.getPrestador().getNomeCompleto();
+        String nomeCliente = pedido.getCliente().getNomeCompleto();
+        String detalhes =
+                linha("Cliente", nomeCliente) +
+                linha("Tipo de evento", pedido.getTipoEvento()) +
+                linha("Data do evento", pedido.getDataEvento().format(FORMATO_DATA)) +
+                linha("Valor orçado", "R$ " + pedido.getValor());
+
+        String rodape = caixa("aviso",
+                "A data voltou a ficar disponível na sua agenda. Continue enviando orçamentos para novos pedidos.");
+
+        return construir(
+                "Orçamento recusado",
+                "Olá, " + nomePrestador + ".",
+                "<strong>" + nomeCliente + "</strong> recusou o orçamento enviado para o evento abaixo.",
+                detalhes,
+                rodape
+        );
+    }
+
     public static String midiaRemovidaPorModeracao(String nomePrestador, String tipoMidia, String tituloItem) {
         String detalhes =
                 linha("Tipo de mídia", tipoMidia) +

--- a/src/main/java/com/gabriel/party/services/pedido/PedidoExpiracaoJob.java
+++ b/src/main/java/com/gabriel/party/services/pedido/PedidoExpiracaoJob.java
@@ -40,12 +40,12 @@ public class PedidoExpiracaoJob {
             pedido.setStatusPedido(StatusPedido.EXPIRADO);
             pedidoRepository.save(pedido);
 
-            emailService.enviarEmail(
+            emailService.enviarAposCommit(
                     pedido.getCliente().getUsuario().getEmail(),
                     "FestConnect - Pedido encerrado",
                     EmailTemplates.prestadorNaoRespondeuParaCliente(pedido)
             );
-            emailService.enviarEmail(
+            emailService.enviarAposCommit(
                     pedido.getPrestador().getUsuario().getEmail(),
                     "FestConnect - Prazo de resposta expirado",
                     EmailTemplates.prazoPerdidoParaPrestador(pedido)
@@ -64,13 +64,13 @@ public class PedidoExpiracaoJob {
             pedido.setStatusPedido(StatusPedido.EXPIRADO);
             pedidoRepository.save(pedido);
 
-            emailService.enviarEmail(
+            emailService.enviarAposCommit(
                     pedido.getCliente().getUsuario().getEmail(),
                     "FestConnect - Orçamento expirado",
                     EmailTemplates.orcamentoExpiradoParaCliente(pedido)
             );
 
-            emailService.enviarEmail(
+            emailService.enviarAposCommit(
                     pedido.getPrestador().getUsuario().getEmail(),
                     "FestConnect - Reserva liberada",
                     EmailTemplates.reservaLiberadaParaPrestador(pedido)

--- a/src/main/java/com/gabriel/party/services/pedido/PedidoService.java
+++ b/src/main/java/com/gabriel/party/services/pedido/PedidoService.java
@@ -206,6 +206,24 @@ public class PedidoService {
     }
 
     @Transactional
+    public void recusarOrcamentoPeloCliente(UUID pedidoId, Usuario usuarioLogado) {
+        Pedido pedido = buscarPedidoComPermissaoCliente(pedidoId, usuarioLogado);
+
+        if (pedido.getStatusPedido() != StatusPedido.ORCADO) {
+            throw new AppException(ErrorCode.PEDIDO_STATUS_INVALIDO, pedido.getStatusPedido().name());
+        }
+
+        pedido.setStatusPedido(StatusPedido.RECUSADO);
+        pedidoRepository.save(pedido);
+
+        emailService.enviarAposCommit(
+                pedido.getPrestador().getUsuario().getEmail(),
+                "FestConnect - Orçamento recusado",
+                EmailTemplates.orcamentoRecusadoPeloClienteParaPrestador(pedido)
+        );
+    }
+
+    @Transactional
     public void cancelarPedidoPeloCliente(UUID pedidoId, Usuario usuarioLogado) {
         Pedido pedido = buscarPedidoComPermissaoCliente(pedidoId, usuarioLogado);
 

--- a/src/test/java/com/gabriel/party/services/pedido/PedidoExpiracaoJobTest.java
+++ b/src/test/java/com/gabriel/party/services/pedido/PedidoExpiracaoJobTest.java
@@ -78,7 +78,7 @@ class PedidoExpiracaoJobTest {
 
         assertThat(pedido.getStatusPedido()).isEqualTo(StatusPedido.EXPIRADO);
         verify(pedidoRepository).save(pedido);
-        verify(emailService).enviarEmail(eq("cliente@test.com"), any(), any());
+        verify(emailService).enviarAposCommit(eq("cliente@test.com"), any(), any());
     }
 
     @Test
@@ -90,7 +90,7 @@ class PedidoExpiracaoJobTest {
         scheduler.expirarPedidosVencidos();
 
         verify(pedidoRepository, never()).save(any());
-        verify(emailService, never()).enviarEmail(any(), any(), any());
+        verify(emailService, never()).enviarAposCommit(any(), any(), any());
     }
 
     @Test
@@ -116,7 +116,7 @@ class PedidoExpiracaoJobTest {
         assertThat(pedido.getStatusPedido()).isEqualTo(StatusPedido.EXPIRADO);
         assertThat(segundoPedido.getStatusPedido()).isEqualTo(StatusPedido.EXPIRADO);
         verify(pedidoRepository, times(2)).save(any());
-        verify(emailService, times(4)).enviarEmail(any(), any(), any());
+        verify(emailService, times(4)).enviarAposCommit(any(), any(), any());
     }
 
     @Test
@@ -133,7 +133,7 @@ class PedidoExpiracaoJobTest {
 
         assertThat(pedido.getStatusPedido()).isEqualTo(StatusPedido.EXPIRADO);
         verify(pedidoRepository).save(pedido);
-        verify(emailService).enviarEmail(eq("cliente@test.com"), any(), any());
-        verify(emailService).enviarEmail(eq("prestador@test.com"), any(), any());
+        verify(emailService).enviarAposCommit(eq("cliente@test.com"), any(), any());
+        verify(emailService).enviarAposCommit(eq("prestador@test.com"), any(), any());
     }
 }


### PR DESCRIPTION
Fecha parte das issues abertas de backend. Commits atômicos por issue.

## Closes #57 — desacoplar e-mail do PedidoExpiracaoJob
Troca `enviarEmail` por `enviarAposCommit` nas 4 notificações do job. O status `EXPIRADO` é commitado independentemente do SMTP; e-mails só disparam após o commit. Teste atualizado.

## Closes #55 — recusa de orçamento pelo cliente
Novo `PUT /api/v1/pedidos/{id}/recusar-orcamento` (ROLE_CLIENTE), que recusa um orçamento `ORCADO` (→ `RECUSADO`) e notifica o prestador (novo template, via afterCommit). Resolve o 403 da #55 com a opção (B). PR de frontend correspondente aponta o botão para o novo endpoint.

## Closes #53 — fotoPerfilUrl no claim do JWT
`TokenService` ganha overload que adiciona o claim `fotoPerfilUrl`; login e OAuth passam a foto do perfil. Cadastros seguem sem foto (perfil recém-criado). Front correspondente lê do token.

Build + testes verdes (PedidoServiceTest, PedidoExpiracaoJobTest, MidiaServiceTest, ItemCatalogoServiceTest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)